### PR TITLE
Minor improvements to reading pw and w90 input files

### DIFF
--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -9,6 +9,7 @@ pycodestyle:  # Same as scanner.linter value. Other option is flake8
     ignore:  # Errors and warnings to ignore
         - W391  # blank line at end of file
         - W503  # line break before binary operator
+        - W504  # line break after binary operator
         - E402  # module level import not at top of file
         - E731  # do not assign a lambda expression, use a def
         - C406  # Unnecessary list literal - rewrite as a dict literal.

--- a/.pep8speaks.yml
+++ b/.pep8speaks.yml
@@ -1,0 +1,29 @@
+# File : .pep8speaks.yml
+
+scanner:
+    diff_only: False  # If False, the entire file touched by the Pull Request is scanned for errors. If True, only the diff is scanned.
+    linter: pycodestyle  # Other option is flake8
+
+pycodestyle:  # Same as scanner.linter value. Other option is flake8
+    max-line-length: 120  # Default is 79 in PEP 8
+    ignore:  # Errors and warnings to ignore
+        - W391  # blank line at end of file
+        - W503  # line break before binary operator
+        - E402  # module level import not at top of file
+        - E731  # do not assign a lambda expression, use a def
+        - C406  # Unnecessary list literal - rewrite as a dict literal.
+        - E741  # ambiguous variable name
+
+no_blank_comment: False  # If True, no comment is made on PR without any errors.
+descending_issues_order: False  # If True, PEP 8 issues in message will be displayed in descending order of line numbers in the file
+
+message:  # Customize the comment made by the bot
+    opened:  # Messages when a new PR is submitted
+        header: "Hello @{name}! Thanks for opening this PR. "
+                # The keyword {name} is converted into the author's username
+        footer: "Do see the [Hitchhiker's guide to code style](https://goo.gl/hqbW4r)"
+                # The messages can be written as they would over GitHub
+    updated:  # Messages when new commits are added to the PR
+        header: "Hello @{name}! Thanks for updating this PR. "
+        footer: ""  # Why to comment the link to the style guide everytime? :)
+    no_errors: "There are currently no PEP 8 issues detected in this Pull Request. Cheers! :beers: "

--- a/ase/calculators/espresso_cp.py
+++ b/ase/calculators/espresso_cp.py
@@ -21,13 +21,14 @@ warn_template = 'Property "%s" is None. Typically, this is because the ' \
                 'Espresso at a "low" verbosity level (the default). ' \
                 'Please try running Quantum Espresso with "high" verbosity.'
 
+
 class Espresso_cp(FileIOCalculator):
     """
     """
     implemented_properties = ['energy']
 
     # User must specify the appropriate command using ASE_ESPRESSO_CP_COMMAND
-    command = None
+    command = 'cp.x -in PREFIX.cpi > PREFIX.cpo'
 
     def __init__(self, restart=None, ignore_bad_restart_file=False,
                  label='espresso', atoms=None, **kwargs):

--- a/ase/io/espresso.py
+++ b/ase/io/espresso.py
@@ -52,8 +52,10 @@ _PW_ELECTROSTATIC_EMBEDDING = 'electrostatic embedding'
 _PW_NITER = 'iteration #'
 _PW_DONE = 'JOB DONE.'
 
+
 class Namelist(OrderedDict):
     """Case insensitive dict that emulates Fortran Namelists."""
+
     def __contains__(self, key):
         return super(Namelist, self).__contains__(key.lower())
 
@@ -506,7 +508,7 @@ def read_espresso_in(fileobj):
 
     # parse namelist section and extract remaining lines
     data, card_lines = read_fortran_namelist(fileobj)
-    
+
     # get the cell if ibrav=0
     if 'system' not in data:
         raise KeyError('Required section &SYSTEM not found.')
@@ -538,8 +540,8 @@ def read_espresso_in(fileobj):
     # TODO: put more info into the atoms object
     # e.g magmom, forces.
     atoms = Atoms(symbols=symbols, positions=positions, cell=cell,
-                  constraint=constraint, pbc=True, 
-                  calculator=Espresso(input_data=data, pseudopotentials = pseudos))
+                  constraint=constraint, pbc=True,
+                  calculator=Espresso(input_data=data, pseudopotentials=pseudos))
     atoms.calc.atoms = atoms
 
     if any(['k_points' in l.lower() for l in card_lines]):
@@ -563,6 +565,7 @@ def get_kpoints(card_lines):
             else:
                 raise ValueError('Failed to parse K_POINTS block')
     raise ValueError('Failed to find K_POINTS block')
+
 
 def ibrav_to_cell(system):
     """
@@ -859,6 +862,7 @@ def get_cell_parameters(lines, alat=None):
 
     return cell, cell_alat
 
+
 def get_pseudopotentials(lines, n_types):
     """Parse atom positions from ATOMIC_SPECIES card.
 
@@ -882,10 +886,10 @@ def get_pseudopotentials(lines, n_types):
     """
 
     i_start = [l.lower() for l in lines].index('atomic_species') + 1
-    pseudos = {l.split()[0] : l.split()[2] for l in lines[i_start:i_start + n_types]}
+    pseudos = {l.split()[0]: l.split()[2] for l in lines[i_start:i_start + n_types]}
 
     return pseudos
-        
+
 
 def str_to_value(string):
     """Attempt to convert string into int, float (including fortran double),
@@ -1568,8 +1572,8 @@ def write_espresso_in(fd, atoms, input_data=None, pseudopotentials=None,
             input_data = atoms.calc.parameters['input_data']
         elif input_data != atoms.calc.parameters['input_data']:
             warnings.warn("write_espresso_in(...) is ignoring "
-                  "atom.calc.parameters['input_data'] in favor of "
-                  "the input_data provided to it as an argument")
+                          "atom.calc.parameters['input_data'] in favor of "
+                          "the input_data provided to it as an argument")
 
     input_parameters = construct_namelist(input_data, **kwargs)
 
@@ -1617,7 +1621,7 @@ def write_espresso_in(fd, atoms, input_data=None, pseudopotentials=None,
             valence = SSSP_VALENCE[atomic_numbers[specie]]
 
         species_info[label] = {'pseudo': pseudo,
-                                 'valence': valence}
+                               'valence': valence}
 
     # Convert atoms into species.
     # Each different magnetic moment needs to be a separate type even with

--- a/ase/io/espresso_cp.py
+++ b/ase/io/espresso_cp.py
@@ -30,7 +30,7 @@ from ase.utils import basestring
 
 from ase.io.espresso import Namelist, SSSP_VALENCE, \
    read_espresso_in, ibrav_to_cell, get_atomic_positions, \
-   get_cell_parameters, str_to_value, read_fortran_namelist, ffloat, \
+   get_cell_parameters, str_to_value, ffloat, \
    label_to_symbol, infix_float, grep_valence, \
    cell_to_ibrav, kspacing_to_grid, write_espresso_in, get_constraint
 from ase.io.espresso import KEYS as PW_KEYS
@@ -131,7 +131,7 @@ def read_espresso_cp_in(fileobj):
     calc = Espresso_cp(input_data=data, pseudopotentials=pseudos)
 
     # Overwriting the Espresso calculator with the new Espresso_cp calculator
-    atoms.set_calculator(calc)
+    atoms.calc = calc
     atoms.calc.atoms = atoms
 
     return atoms
@@ -283,7 +283,7 @@ def read_espresso_cp_out(fileobj, index=-1, results_required=True):
     calc.results['convergence'] = convergence
     calc.results['job_done'] = job_done
     calc.results['walltime'] = walltime
-    structure.set_calculator(calc)
+    structure.calc = calc
 
     yield structure
 

--- a/ase/io/espresso_cp.py
+++ b/ase/io/espresso_cp.py
@@ -29,10 +29,10 @@ from ase.units import create_units
 from ase.utils import basestring
 
 from ase.io.espresso import Namelist, SSSP_VALENCE, \
-   read_espresso_in, ibrav_to_cell, get_atomic_positions, \
-   get_cell_parameters, str_to_value, ffloat, \
-   label_to_symbol, infix_float, grep_valence, \
-   cell_to_ibrav, kspacing_to_grid, write_espresso_in, get_constraint
+    read_espresso_in, ibrav_to_cell, get_atomic_positions, \
+    get_cell_parameters, str_to_value, ffloat, \
+    label_to_symbol, infix_float, grep_valence, \
+    cell_to_ibrav, kspacing_to_grid, write_espresso_in, get_constraint
 from ase.io.espresso import KEYS as PW_KEYS
 
 from ase.calculators.espresso_cp import Espresso_cp
@@ -41,22 +41,22 @@ from ase.calculators.espresso_cp import Espresso_cp
 units = create_units('2006')
 
 KEYS = copy.deepcopy(PW_KEYS)
-KEYS['CONTROL']   += ['ndr', 'ndw', 'ekin_conv_thr', 'write_hr']
-KEYS['SYSTEM']    += ['fixed_band', 'f_cutoff', 'restart_from_wannier_pwscf', 'do_orbdep', 
-                      'fixed_state', 'do_ee', 'nelec', 'nelup', 'neldw', 'do_wf_cmplx', 
-                      'nr1b', 'nr2b', 'nr3b']
-KEYS['ELECTRONS'] += ['empty_states_nbnd', 'maxiter', 'empty_states_maxstep', 
+KEYS['CONTROL'] += ['ndr', 'ndw', 'ekin_conv_thr', 'write_hr']
+KEYS['SYSTEM'] += ['fixed_band', 'f_cutoff', 'restart_from_wannier_pwscf', 'do_orbdep',
+                   'fixed_state', 'do_ee', 'nelec', 'nelup', 'neldw', 'do_wf_cmplx',
+                   'nr1b', 'nr2b', 'nr3b']
+KEYS['ELECTRONS'] += ['empty_states_nbnd', 'maxiter', 'empty_states_maxstep',
                       'electron_dynamics', 'passop', 'do_outerloop', 'do_outerloop_empty']
-KEYS['EE']         = ['which_compensation', 'tcc_odd']
-KEYS['NKSIC']      = ['do_innerloop', 'nkscalfact', 'odd_nkscalfact', 
-                      'odd_nkscalfact_empty', 'which_orbdep', 'print_wfc_anion', 
-                      'index_empty_to_save', 'innerloop_cg_nreset', 'innerloop_cg_nsd', 
-                      'innerloop_init_n', 'hartree_only_sic', 'esic_conv_thr', 
-                      'do_innerloop_cg', 'innerloop_nmax', 'do_innerloop_empty', 
-                      'innerloop_cg_ratio', 'fref', 'kfact', 'wo_odd_in_empty_run', 
-                      'aux_empty_nbnd', 'print_evc0_occ_empty']
-KEYS['IONS']      += ['ion_nstepe', 'ion_radius(1)', 'ion_radius(2)', 'ion_radius(3)',
-                      'ion_radius(4)'] 
+KEYS['EE'] = ['which_compensation', 'tcc_odd']
+KEYS['NKSIC'] = ['do_innerloop', 'nkscalfact', 'odd_nkscalfact',
+                 'odd_nkscalfact_empty', 'which_orbdep', 'print_wfc_anion',
+                 'index_empty_to_save', 'innerloop_cg_nreset', 'innerloop_cg_nsd',
+                 'innerloop_init_n', 'hartree_only_sic', 'esic_conv_thr',
+                 'do_innerloop_cg', 'innerloop_nmax', 'do_innerloop_empty',
+                 'innerloop_cg_ratio', 'fref', 'kfact', 'wo_odd_in_empty_run',
+                 'aux_empty_nbnd', 'print_evc0_occ_empty']
+KEYS['IONS'] += ['ion_nstepe', 'ion_radius(1)', 'ion_radius(2)', 'ion_radius(3)',
+                 'ion_radius(4)']
 
 # Section identifiers
 _CP_START = 'CP: variable-cell Car-Parrinello molecular dynamics'
@@ -73,16 +73,17 @@ _CP_LAMBDA = 'fixed_lambda'
 # _CP_KPTS =
 # _CP_BANDSTRUCTURE =
 
+
 def write_espresso_cp_in(fd, atoms, input_data=None, pseudopotentials=None,
-                      kspacing=None, kpts=None, koffset=(0, 0, 0),
-                      **kwargs):
+                         kspacing=None, kpts=None, koffset=(0, 0, 0),
+                         **kwargs):
 
     write_espresso_in(fd, atoms, input_data, pseudopotentials,
                       kspacing, kpts, koffset, **kwargs)
 
     if not fd.closed:
         fd.close()
-    
+
     # Extra blocks
     extra_lines = []
     input_parameters = construct_namelist(input_data, **kwargs)
@@ -115,7 +116,7 @@ def write_espresso_cp_in(fd, atoms, input_data=None, pseudopotentials=None,
             kpts_start = after.index(line)
             break
     kpts_end = after[kpts_start:].index('\n') + kpts_start
-    del after[kpts_start:kpts_end+1]
+    del after[kpts_start:kpts_end + 1]
 
     # Rewrite the file with the extra blocks
     with open(fd.name, 'w') as fd_rewrite:

--- a/ase/io/espresso_cp.py
+++ b/ase/io/espresso_cp.py
@@ -204,12 +204,12 @@ def read_espresso_cp_out(fileobj, index=-1, results_required=True):
         if _CP_BANDS in line:
             try:
                 eigenvalues.append([float(e) for e in cpo_lines[i_line + 2].split()])
-            except:
+            except ValueError:
                 pass
             if 'Empty States Eigenvalues' in cpo_lines[i_line + 4]:
                 try:
                     eigenvalues[-1] += [float(e) for e in cpo_lines[i_line + 6].split()]
-                except:
+                except ValueError:
                     pass
 
         if 'odd energy' in line:

--- a/ase/io/pw2wannier.py
+++ b/ase/io/pw2wannier.py
@@ -7,6 +7,7 @@ from ase.atoms import Atoms
 from ase.calculators.pw2wannier import PW2Wannier
 from ase.io.espresso import Namelist, read_fortran_namelist
 
+
 def read_pw2wannier_in(fileobj):
     """Parse a pw2wannier input file, 'pw2wan', '.p2wi'
 
@@ -36,7 +37,7 @@ def read_pw2wannier_in(fileobj):
 
     # parse namelist section and extract remaining lines
     data, _ = read_fortran_namelist(fileobj)
-    
+
     if 'inputpp' not in data:
         raise KeyError('Required section &inputpp not found.')
 

--- a/ase/io/pw2wannier.py
+++ b/ase/io/pw2wannier.py
@@ -113,6 +113,6 @@ def read_pw2wannier_out(fd):
     calc = PW2Wannier(atoms=structure)
     calc.results['job done'] = job_done
 
-    structure.set_calculator(calc)
+    structure.calc = calc
 
     yield structure

--- a/ase/io/wannier90.py
+++ b/ase/io/wannier90.py
@@ -11,6 +11,7 @@ from ase.utils import basestring
 from ase.atoms import Atoms
 from ase.calculators.wannier90 import Wannier90
 
+
 def parse_value(value):
     if isinstance(value, list):
         parsed_value = []
@@ -23,10 +24,11 @@ def parse_value(value):
             elif value.lower() in ['f', 'false', '.true.']:
                 return False
         try:
-           parsed_value = json.loads(value)
+            parsed_value = json.loads(value)
         except:
-           parsed_value = value
+            parsed_value = value
     return parsed_value
+
 
 def write_wannier90_in(fd, atoms):
     """
@@ -42,25 +44,25 @@ def write_wannier90_in(fd, atoms):
 
         if kw == 'kpts':
             if np.ndim(opt) == 2:
-                rows_str = [' '.join([str(v) for v in row] + [str(1/len(opt))]) for row in opt]
+                rows_str = [' '.join([str(v) for v in row] + [str(1 / len(opt))]) for row in opt]
                 fd.write(block_format('kpoints', rows_str))
 
         elif kw == 'projections':
             rows_str = []
             if 'units' in opt:
-               rows_str.append(opt['units'])
+                rows_str.append(opt['units'])
             for [site, proj] in opt['sites']:
-               if isinstance(site, list):
-                  # Interpret as fractional coordinates
-                  site_str = 'f=' + ','.join([str(v) for v in site])
-               else:
-                  # Interpret as atom label
-                  site_str = str(site)
-               if isinstance(proj, list):
-                  proj_str = ';'.join(proj)
-               else:
-                  proj_str = str(proj)
-               rows_str.append(f'{site_str}: {proj_str}')
+                if isinstance(site, list):
+                    # Interpret as fractional coordinates
+                    site_str = 'f=' + ','.join([str(v) for v in site])
+                else:
+                    # Interpret as atom label
+                    site_str = str(site)
+                if isinstance(proj, list):
+                    proj_str = ';'.join(proj)
+                else:
+                    proj_str = str(proj)
+                rows_str.append(f'{site_str}: {proj_str}')
             fd.write(block_format(kw, rows_str))
 
         elif kw == 'mp_grid':
@@ -69,7 +71,7 @@ def write_wannier90_in(fd, atoms):
 
         elif isinstance(opt, list):
             if np.ndim(opt) == 1:
-               opt = [opt]
+                opt = [opt]
             rows_str = [' '.join([str(v) for v in row]) for row in opt]
             fd.write(block_format(kw, rows_str))
 
@@ -95,9 +97,11 @@ def write_wannier90_in(fd, atoms):
     rows_str = ['ang'] + [' '.join([str(v) for v in row]) for row in atoms.cell]
     fd.write(block_format('unit_cell_cart', rows_str))
 
+
 def block_format(name, rows_str):
     joined_rows = '\n'.join(['  ' + r for r in rows_str])
     return f'\nbegin {name}\n{joined_rows}\nend {name}\n'
+
 
 def read_wannier90_in(fd):
     """

--- a/ase/io/wannier90.py
+++ b/ase/io/wannier90.py
@@ -25,7 +25,7 @@ def parse_value(value):
                 return False
         try:
             parsed_value = json.loads(value)
-        except:
+        except (TypeError, json.decoder.JSONDecodeError) as e:
             parsed_value = value
     return parsed_value
 


### PR DESCRIPTION
- extended support for parsing `K_POINTS` block in `read_espresso_in`
- extended support for parsing `unit_cell_cart`, `atoms_frac`, and `projections` to `read_wannier90_in`
- removed calls to `set_calculator()` (which is being deprecated)
- added default `cp` command (so in principle someone can test `run_koopmans.py` without `cp.x` installed)
- pep8 compliance