### PR TITLE
Fixed bug in writing of pw files with kpoints

### DIFF
--- a/ase/io/espresso.py
+++ b/ase/io/espresso.py
@@ -1741,6 +1741,10 @@ def write_espresso_in(fd, atoms, input_data=None, pseudopotentials=None,
     pwi.append('\n')
 
     # KPOINTS - add a MP grid as required
+    kpts_via_parameters = atoms.calc.parameters.get('kpts', None)
+    if kpts is None and kpts_via_parameters is not None:
+        kpts = kpts_via_parameters
+
     if kspacing is not None:
         kgrid = kspacing_to_grid(atoms, kspacing)
     elif kpts is not None:


### PR DESCRIPTION
Previously ASE required `kpts` to be provided as an explicit argument to `write_espresso_in`. Now if it's not provided as an argument it checks if `atoms.calc.parameters['kpts']` has been set