### PR TITLE
Bugfix for reading in two numbers with no space separating them

### DIFF
--- a/ase/io/espresso/utils.py
+++ b/ase/io/espresso/utils.py
@@ -1041,7 +1041,7 @@ def safe_float(string):
 
 def safe_string_to_list_of_floats(string):
     # Converts a string to a list of floats, but if string = 'number*******anothernumber' it returns
-    # [number, np.nan, anothernumber]
+    # [number, np.nan, anothernumber]. It also keeps its eye out for cases like numberanothernumber
     out = []
     for word in string.split():
         if '*' in word:
@@ -1055,5 +1055,10 @@ def safe_string_to_list_of_floats(string):
             # Finally, convert to float
             out += [safe_float(x) for x in word.split()]
         else:
-            out.append(safe_float(word))
+            if word.count('.') > 1:
+                # For cases where a number almost overflows we might get a single "word" with multiple
+                # decimal points...
+                out += [np.nan for _ in range(word.count('.'))]
+            else:
+                out.append(safe_float(word))
     return out


### PR DESCRIPTION
Very minor bugfix to deal with an edge case in QE when a float is formatted such that there is no space separating it from its neighbours e.g.
```
...
   -0.4228   -0.4224   -0.4224   -0.3237   -0.3197   -0.3197   -0.2345   -0.2345   -0.2341   -0.1901
   -0.1901   -0.1896   -0.1821   -0.1479   -0.1469   -0.1466   -0.0001    0.0142    0.0152    0.0152
    0.0774    0.0774    0.078111766.3260
...
```

Now the code will simply interpret these last two numbers as `NaN`s