### PR TITLE
Various bugfixes to the espresso calculators

### DIFF
--- a/ase/io/espresso/koopmans_ham.py
+++ b/ase/io/espresso/koopmans_ham.py
@@ -10,7 +10,7 @@ from ase.calculators.singlepoint import SinglePointDFTCalculator
 from ase.dft.kpoints import BandPath
 from ase.utils import basestring
 from .utils import construct_kpoints_card, generic_construct_namelist, safe_string_to_list_of_floats, time_to_float, \
-    read_fortran_namelist, get_kpoints
+    read_fortran_namelist
 from .wann2kc import KEYS as W2KKEYS
 
 from ase.calculators.espresso import KoopmansHam

--- a/ase/io/espresso/koopmans_ham.py
+++ b/ase/io/espresso/koopmans_ham.py
@@ -106,14 +106,14 @@ def read_koopmans_ham_out(fileobj):
                 eigenvalues[-1] += [float(x) for x in line2.split()]
                 j_line += 1
 
-        if 'INFO: KC HAMILTONIAN CALCULATION ik=' in line:
+        if 'INFO: KI[2nd] HAMILTONIAN CALCULATION ik=' in line:
             ks_eigenvalues_on_grid.append([])
             ki_eigenvalues_on_grid.append([])
 
-        if line.startswith('          KS'):
+        if line.startswith('          KS '):
             ks_eigenvalues_on_grid[-1] += safe_string_to_list_of_floats(line.replace('KS', ''))
 
-        if line.startswith('          KI'):
+        if line.startswith('          KI '):
             ki_eigenvalues_on_grid[-1] += safe_string_to_list_of_floats(line.replace('KI', ''))
 
         if 'JOB DONE' in line:

--- a/ase/io/espresso/koopmans_screen.py
+++ b/ase/io/espresso/koopmans_screen.py
@@ -81,12 +81,12 @@ def read_koopmans_screen_out(fileobj):
     # Extract calculation results
     job_done = False
     walltime = None
-    alphas = []
+    alphas = [[]]
     orbital_data = {'self-Hartree': []}
     for i_line, line in enumerate(flines):
         if 'relaxed' in line:
             splitline = line.split()
-            alphas.append(float(splitline[-5]))
+            alphas[-1].append(float(splitline[-5]))
             orbital_data['self-Hartree'].append(float(splitline[-1]) * units.Ry)
 
         if 'JOB DONE' in line:

--- a/ase/io/espresso/pw.py
+++ b/ase/io/espresso/pw.py
@@ -533,7 +533,8 @@ def read_pw_in(fileobj):
     atoms.calc.atoms = atoms
 
     if any(['k_points' in l.lower() for l in card_lines]):
-        atoms.calc.parameters['kpts'], atoms.calc.parameters['koffset'] = get_kpoints(card_lines, cell=atoms.cell)
+        for k, v in zip(['kpts', 'koffset', 'gamma_only'], get_kpoints(card_lines, cell=atoms.cell)):
+            atoms.calc.parameters[k] = v
 
     return atoms
 
@@ -595,5 +596,4 @@ def construct_namelist(parameters=None, warn=False, **kwargs):
 
 
 def write_pw_in(*args, **kwargs):
-    kwargs['local_construct_namelist'] = construct_namelist
-    write_espresso_in(*args, **kwargs)
+    write_espresso_in(*args, local_construct_namelist=construct_namelist, **kwargs)

--- a/ase/io/wannier90.py
+++ b/ase/io/wannier90.py
@@ -395,9 +395,9 @@ def num_wann_from_projections(projections: List[Dict[str, Any]], atoms: Atoms):
     for proj in projections:
         if 'site' in proj:
             if atoms.has('labels'):
-                labels = atoms.get_array('labels')
+                labels = atoms.get_array('labels').tolist()
             else:
-                labels = atoms.symbols
+                labels = [s for s in atoms.symbols]
             num_sites = labels.count(proj['site'])
         else:
             num_sites = 1

--- a/ase/io/wannier90.py
+++ b/ase/io/wannier90.py
@@ -390,7 +390,7 @@ def read_wannier90_out(fd):
 def num_wann_from_projections(projections: List[Dict[str, Any]], atoms: Atoms):
     # Works out the value of 'num_wann' based on the 'projections' block
     num_wann_lookup = {'s': 1, 'p': 3, 'd': 5, 'sp': 2, 'sp2': 3, 'sp3': 4, 'sp3d': 5, 'sp3d2': 6,
-                       'l=0': 1, 'l=1': 3, 'l=2': 5}
+                       'l=0': 1, 'l=1': 3, 'l=2': 5, 'l=-3': 4}
     num_wann = 0
     for proj in projections:
         if 'site' in proj:
@@ -405,7 +405,7 @@ def num_wann_from_projections(projections: List[Dict[str, Any]], atoms: Atoms):
         ang_mtms = proj['ang_mtm'].split(';')
         if not all([ang_mtm in num_wann_lookup for ang_mtm in ang_mtms]):
             raise NotImplementedError(
-                f'I cannot work out how many projections will result from {proj["ang_mtm"]}. '
+                f'Cannot work out how many projections will result from {proj["ang_mtm"]}. '
                 'Please specify num_wann manually.')
 
         num_wann += num_sites * sum([num_wann_lookup[ang_mtm] for ang_mtm in ang_mtms])


### PR DESCRIPTION
For the espresso calculators...
- changes to parsing `koopmans_ham` output to reflect changes in that code
- improved parsing of spin-polarised alpha
- distinction drawn between `K_POINTS gamma` and `K_POINTS automatic 1 1 1 0 0 0` via the `gamma_only` parameter
- fixing bugs in parsing k paths
- added support for parsing more w90 projections