### PR TITLE
Support for improved koopmans json writing

### DIFF
--- a/ase/calculators/espresso/_koopmans_ham.py
+++ b/ase/calculators/espresso/_koopmans_ham.py
@@ -27,7 +27,7 @@ class KoopmansHam(EspressoWithBandstructure, EspressoParent):
 
     def read_results(self):
         super().read_results()
-        if isinstance(self.parameters.kpts, BandPath) and len(self.parameters.kpts.kpts) > 0:
+        if isinstance(self.parameters.kpts, BandPath) and len(self.parameters.kpts.kpts) > 1:
             # Add the bandstructure to the results
             self.band_structure(vbm_to_zero=True)
 

--- a/ase/dft/kpoints.py
+++ b/ase/dft/kpoints.py
@@ -337,6 +337,16 @@ class BandPath:
         # Temp compatibility stuff, see __iter__
         return tuple(self)[index]
 
+    def __eq__(self, other):
+        if isinstance(other, BandPath):
+            if not np.all(self.cell == other.cell):
+                return False
+            elif self.path != other.path:
+                return False
+            else:
+                return np.all(self.kpts == other.kpts)
+        return False
+
     def get_linear_kpoint_axis(self, eps=1e-5):
         """Define x axis suitable for plotting a band structure.
 

--- a/ase/dft/kpoints.py
+++ b/ase/dft/kpoints.py
@@ -339,12 +339,12 @@ class BandPath:
 
     def __eq__(self, other):
         if isinstance(other, BandPath):
-            if not np.all(self.cell == other.cell):
+            if not np.allclose(self.cell, other.cell, atol=1e-10):
                 return False
             elif self.path != other.path:
                 return False
             else:
-                return np.all(self.kpts == other.kpts)
+                return np.allclose(self.kpts, other.kpts, atol=1e-10)
         return False
 
     def get_linear_kpoint_axis(self, eps=1e-5):


### PR DESCRIPTION
Two very minor changes required by Koopmans:

- kcw's hamiltonian mode should not try and generate a bandpath if the kpath has length 1
- added `__eq__` implementation for the `BandPath` class