### PR TITLE
Compliance with new format of KCW

### DIFF
--- a/ase/calculators/espresso/_koopmans_ham.py
+++ b/ase/calculators/espresso/_koopmans_ham.py
@@ -1,10 +1,10 @@
-""" Calculator for koopmans_ham.x, a code for performing Koopmans calculations in periodic systems
+""" Calculator for kcw.x (ham mode), a code for performing Koopmans calculations in periodic systems
 
-export ASE_KOOPMANS_HAM_COMMAND="/path/to/kc_ham.x -in PREFIX.khi > PREFIX.kho"
+export ASE_KOOPMANS_HAM_COMMAND="/path/to/kcw.x -in PREFIX.khi > PREFIX.kho"
 
 N.B. the extensions must be .khi and .kho
 
-Run kc_ham.x jobs.
+Run kcw.x jobs in the 'ham' mode.
 """
 
 
@@ -18,8 +18,8 @@ class KoopmansHam(EspressoWithBandstructure, EspressoParent):
     ext_out = '.kho'
     implemented_properties = []
 
-    # Default command does not use parallelism and assumes kc_ham.x is on the user's path
-    command = 'kc_ham.x -in PREFIX.khi > PREFIX.kho'
+    # Default command does not use parallelism and assumes kcw.x is on the user's path
+    command = 'kcw.x -in PREFIX.khi > PREFIX.kho'
 
     def __init__(self, *args, **kwargs):
         kwargs['label'] = 'kc_ham'

--- a/ase/calculators/espresso/_koopmans_screen.py
+++ b/ase/calculators/espresso/_koopmans_screen.py
@@ -1,10 +1,10 @@
-""" Calculator for koopmans_screen.x, a code for performing Koopmans calculations in periodic systems
+""" Calculator for kcw.x (screen mode), a code for performing Koopmans calculations in periodic systems
 
-export ASE_KOOPMANS_HAM_COMMAND="/path/to/kc_screen.x -in PREFIX.khi > PREFIX.kho"
+export ASE_KOOPMANS_HAM_COMMAND="/path/to/kcw.x -in PREFIX.ksi > PREFIX.kso"
 
 N.B. the extensions must be .ksi and .kso
 
-Run kc_screen.x jobs.
+Run kcw.x jobs in the 'screen' mode.
 """
 
 
@@ -16,8 +16,8 @@ class KoopmansScreen(EspressoParent):
     ext_out = '.kso'
     implemented_properties = []
 
-    # Default command does not use parallelism and assumes kc_screen.x is on the user's path
-    command = 'kc_screen.x -in PREFIX.ksi > PREFIX.kso'
+    # Default command does not use parallelism and assumes kcw.x is on the user's path
+    command = 'kcw.x -in PREFIX.ksi > PREFIX.kso'
 
     def __init__(self, *args, **kwargs):
         kwargs['label'] = 'kc_screen'

--- a/ase/calculators/espresso/_wann2kc.py
+++ b/ase/calculators/espresso/_wann2kc.py
@@ -1,10 +1,10 @@
-""" Calculator for wann_to_kc.x, a code for performing Koopmans calculations in periodic systems
+""" Calculator for kcw.x (wann2kcw mode), a code for performing Koopmans calculations in periodic systems
 
-export ASE_KOOPMANS_HAM_COMMAND="/path/to/wann_to_kc.x -in PREFIX.w2ki > PREFIX.w2ko"
+export ASE_KOOPMANS_HAM_COMMAND="/path/to/kcw.x -in PREFIX.w2ki > PREFIX.w2ko"
 
 N.B. the extensions must be .w2ki and .w2ko
 
-Run wann_to_kc.x jobs.
+Run kcw.x jobs in the 'wann2kcw' mode.
 """
 
 
@@ -16,8 +16,8 @@ class Wann2KC(EspressoParent):
     ext_out = '.w2ko'
     implemented_properties = []
 
-    # Default command does not use parallelism and assumes wann2kc.x is on the user's path
-    command = 'wann2kc.x -in PREFIX.w2ki > PREFIX.w2ko'
+    # Default command does not use parallelism and assumes kcw.x is on the user's path
+    command = 'kcw.x -in PREFIX.w2ki > PREFIX.w2ko'
 
     def __init__(self, *args, **kwargs):
         kwargs['label'] = 'wann2kc'

--- a/ase/io/espresso/koopmans_ham.py
+++ b/ase/io/espresso/koopmans_ham.py
@@ -1,7 +1,7 @@
 """Reads Koopmans Ham files
 
-Read structures and results from koopmans_ham.x output files. Read
-structures from koopmans_ham.x input files.
+Read structures and results from kcw.x (ham mode) output files.
+Read structures from kcw.x (ham mode) input files.
 """
 
 import copy
@@ -16,7 +16,7 @@ from .wann2kc import KEYS as W2KKEYS
 from ase.calculators.espresso import KoopmansHam
 
 KEYS = copy.deepcopy(W2KKEYS)
-KEYS['HAM'] = ['do_bands', 'use_ws_distance', 'write_hr', 'l_alpha_corr', 'lrpa', 'mp1', 'mp2', 'mp3']
+KEYS['HAM'] = ['do_bands', 'use_ws_distance', 'write_hr', 'l_alpha_corr']
 
 
 def write_koopmans_ham_in(fd, atoms, input_data=None, pseudopotentials=None,
@@ -26,13 +26,15 @@ def write_koopmans_ham_in(fd, atoms, input_data=None, pseudopotentials=None,
         input_data = atoms.calc.parameters['input_data']
 
     input_parameters = construct_namelist(input_data, **kwargs)
-    lines = []
 
+    assert input_parameters['CONTROL']['calculation'] == 'ham'
+
+    lines = []
     for section in input_parameters:
         assert section in KEYS.keys()
 
-        if section == 'WANNIER' and not input_parameters['CONTROL'].get('kc_at_ks', True):
-            # Do not write the WANNIER section if kc_at_ks is true
+        if section == 'WANNIER' and not input_parameters['CONTROL'].get('kcw_at_ks', True):
+            # Do not write the WANNIER section if kcw_at_ks is true
             continue
 
         lines.append('&{0}\n'.format(section.upper()))

--- a/ase/io/espresso/koopmans_screen.py
+++ b/ase/io/espresso/koopmans_screen.py
@@ -1,7 +1,7 @@
 """Reads Koopmans Screen files
 
-Read structures and results from koopmans_screen.x output files. Read
-structures from koopmans_screen.x input files.
+Read structures and results from kcw.x (screen mode) output files.
+Read structures from kcw.x (screen mode) input files.
 """
 
 import copy
@@ -13,7 +13,7 @@ from .wann2kc import KEYS as W2KKEYS
 from ase.calculators.espresso import KoopmansScreen
 
 KEYS = copy.deepcopy(W2KKEYS)
-KEYS['SCREEN'] = ['tr2_ph', 'nmix_ph', 'niter_ph', 'lrpa', 'mp1', 'mp2', 'mp3', 'eps_inf', 'i_orb', 'check_spread']
+KEYS['SCREEN'] = ['tr2', 'nmix', 'niter', 'eps_inf', 'i_orb', 'check_spread']
 
 
 def write_koopmans_screen_in(fd, atoms, input_data=None, **kwargs):
@@ -23,12 +23,14 @@ def write_koopmans_screen_in(fd, atoms, input_data=None, **kwargs):
 
     input_parameters = construct_namelist(input_data, **kwargs)
 
+    assert input_parameters['CONTROL']['calculation'] == 'screen'
+
     lines = []
     for section in input_parameters:
         assert section in KEYS.keys()
 
-        if section == 'WANNIER' and not input_parameters['CONTROL'].get('kc_at_ks', True):
-            # Do not write the WANNIER section if kc_at_ks is true
+        if section == 'WANNIER' and not input_parameters['CONTROL'].get('kcw_at_ks', True):
+            # Do not write the WANNIER section if kcw_at_ks is true
             continue
 
         lines.append('&{0}\n'.format(section.upper()))

--- a/ase/io/espresso/pw.py
+++ b/ase/io/espresso/pw.py
@@ -261,7 +261,7 @@ def read_pw_out(fileobj, index=-1, results_required=True):
         for magmoms_index in indexes[_PW_MAGMOM]:
             if image_index < magmoms_index < next_index:
                 magmoms = [
-                    float(mag_line.split()[6]) for mag_line
+                    float(mag_line.split('=')[-1]) for mag_line
                     in pwo_lines[magmoms_index + 1:
                                  magmoms_index + 1 + len(structure)]]
 

--- a/ase/io/espresso/pw.py
+++ b/ase/io/espresso/pw.py
@@ -259,7 +259,6 @@ def read_pw_out(fileobj, index=-1, results_required=True):
         # Magmoms
         magmoms = None
         for magmoms_index in indexes[_PW_MAGMOM]:
-            import ipdb; ipdb.set_trace()
             if image_index < magmoms_index < next_index:
                 magmoms = [
                     float(mag_line.split()[6]) for mag_line

--- a/ase/io/espresso/pw.py
+++ b/ase/io/espresso/pw.py
@@ -259,9 +259,10 @@ def read_pw_out(fileobj, index=-1, results_required=True):
         # Magmoms
         magmoms = None
         for magmoms_index in indexes[_PW_MAGMOM]:
+            import ipdb; ipdb.set_trace()
             if image_index < magmoms_index < next_index:
                 magmoms = [
-                    float(mag_line.split()[5]) for mag_line
+                    float(mag_line.split()[6]) for mag_line
                     in pwo_lines[magmoms_index + 1:
                                  magmoms_index + 1 + len(structure)]]
 

--- a/ase/io/espresso/wann2kc.py
+++ b/ase/io/espresso/wann2kc.py
@@ -1,7 +1,7 @@
-"""Reads Wannier to KC files
+"""Reads Wannier to KCW files
 
-Read structures and results from koopmans_ham.x output files. Read
-structures from wannier_to_kc.x input files.
+Read structures and results from kcw.x (wann2kcw mode) output files.
+Read structures from kcw.x (wann2kcw mode) input files.
 
 """
 
@@ -13,8 +13,8 @@ from ase.calculators.espresso import Wann2KC
 
 
 KEYS = Namelist((
-    ('control', ['prefix', 'outdir', 'kc_iverbosity', 'kc_at_ks',
-                 'homo_only', 'read_unitary_matrix', 'l_vcut', 'assume_isolated']),
+    ('control', ['prefix', 'outdir', 'kcw_iverbosity', 'kcw_at_ks', 'calculation', 'lrpa',
+                 'mp1', 'mp2', 'mp3', 'homo_only', 'read_unitary_matrix', 'l_vcut', 'assume_isolated']),
     ('wannier', ['seedname', 'check_ks', 'num_wann_occ', 'num_wann_emp', 'have_empty', 'has_disentangle'])))
 
 
@@ -25,6 +25,9 @@ def write_wann2kc_in(fd, atoms, input_data=None, pseudopotentials=None,
         input_data = atoms.calc.parameters['input_data']
 
     input_parameters = construct_namelist(input_data, **kwargs)
+
+    assert input_parameters['CONTROL']['calculation'] == 'wann2kcw'
+
     lines = []
     for section in input_parameters:
         assert section in KEYS.keys()

--- a/ase/io/formats.py
+++ b/ase/io/formats.py
@@ -380,8 +380,8 @@ F('vasp-xml', 'VASP vasprun.xml file', '+F',
 F('vti', 'VTK XML Image Data', '1F', module='vtkxml'),
 F('vtu', 'VTK XML Unstructured Grid', '1F', module='vtkxml'),
 F('x3d', 'X3D', '1S'),
-F('wann2kc-out', 'wannier_to_kc.x output file', '1F', module='espresso', ext='w2ko')
-F('wann2kc-in', 'wannier_to_kc.x input file', '1F', module='espresso', ext='w2ki')
+F('wann2kc-out', 'Wannier 90 to KCW output file', '1F', module='espresso', ext='w2ko')
+F('wann2kc-in', 'Wannier 90 to KCW input file', '1F', module='espresso', ext='w2ki')
 F('wannier90-out', 'Wannier 90 output file', '1F', module='wannier90', ext='wout')
 F('wannier90-in', 'Wannier 90 input file', '1F', module='wannier90', ext='win')
 F('xsd', 'Materials Studio file', '1F'),


### PR DESCRIPTION
The programs `wann2kc.x`, `kc_ham.x` and `kc_screen.x` have been replaced by a single executable called `kcw.x`, that runs the three different modalities.

Given the different functionalities that each mode has, the files have been kept separated.

This PR includes small adaptations related to this.

Minor changes also due to upgrade to QE v7.0.