### PR TITLE
Small correction parsing w90 output files

### DIFF
--- a/ase/io/wannier90.py
+++ b/ase/io/wannier90.py
@@ -430,7 +430,7 @@ def read_wannier90_out(fd):
             j = 1
             while 'WF centre and spread' in flines[i + j]:
                 splitline = [x.rstrip(',') for x in re.sub('[(),]', ' ', flines[i + j]).split()]
-                centers.append([float(x) for x in splitline[6:9]])
+                centers.append([float(x) for x in splitline[5:8]])
                 spreads.append(float(splitline[-1]))
                 j += 1
 


### PR DESCRIPTION
This is just a minor correction of the function read_wannier90_out. Previously, the extracted centers contained the arrays [center_y,center_z,spread], now it should contain [center_x,center_y,center_z] as intended. 