### PR TITLE
Removing np.int, safer parsing of eigenvalues, and new argument for `BandStructure.subtract_reference()`

### DIFF
--- a/ase/build/tools.py
+++ b/ase/build/tools.py
@@ -143,8 +143,7 @@ def cut(atoms, a=(1, 0, 0), b=(0, 1, 0), c=None, clength=None,
                 mask = np.concatenate(([True], np.diff(d[keys]) > tol))
                 tags = np.cumsum(mask)[ikeys] - 1
                 levels = d[keys][mask]
-                if (maxatoms is None or len(at) < maxatoms or
-                    len(levels) > nlayers):
+                if (maxatoms is None or len(at) < maxatoms or len(levels) > nlayers):
                     break
                 tol *= 0.9
             if len(levels) > nlayers:
@@ -258,8 +257,7 @@ def stack(atoms1, atoms2, axis=2, cell=None, fix=0.5,
         if not atoms.cell[axis].any():
             atoms.center(vacuum=0.0, axis=axis)
 
-    if (np.sign(np.linalg.det(atoms1.cell)) !=
-        np.sign(np.linalg.det(atoms2.cell))):
+    if (np.sign(np.linalg.det(atoms1.cell)) != np.sign(np.linalg.det(atoms2.cell))):
         raise IncompatibleCellError('Cells of *atoms1* and *atoms2* must have '
                                     'same handedness.')
 

--- a/ase/build/tools.py
+++ b/ase/build/tools.py
@@ -429,7 +429,7 @@ def niggli_reduce_cell(cell, epsfactor=None):
 
     if epsfactor is None:
         epsfactor = 1e-5
-    eps = epsfactor * abs(np.linalg.det(cell))**(1./3.)
+    eps = epsfactor * abs(np.linalg.det(cell))**(1. / 3.)
 
     cell = np.asarray(cell)
 
@@ -472,8 +472,8 @@ def niggli_reduce_cell(cell, epsfactor=None):
             g = np.dot(D, g0)
             continue
 
-        lmn = np.array(gt(g[3:], 0, eps=eps/2), dtype=int)
-        lmn -= np.array(lt(g[3:], 0, eps=eps/2), dtype=int)
+        lmn = np.array(gt(g[3:], 0, eps=eps / 2), dtype=int)
+        lmn -= np.array(lt(g[3:], 0, eps=eps / 2), dtype=int)
 
         if lmn.prod() == 1:
             ijk = lmn.copy()
@@ -502,7 +502,7 @@ def niggli_reduce_cell(cell, epsfactor=None):
         if (gt(abs(g[3]), g[1])
                 or (eq(g[3], g[1]) and lt(2 * g[4], g[5]))
                 or (eq(g[3], -g[1]) and lt(g[5], 0))):
-            s = np.int(np.sign(g[3]))
+            s = int(np.sign(g[3]))
 
             A = I3.copy()
             A[1, 2] = -s
@@ -518,7 +518,7 @@ def niggli_reduce_cell(cell, epsfactor=None):
         elif (gt(abs(g[4]), g[0])
                 or (eq(g[4], g[0]) and lt(2 * g[3], g[5]))
                 or (eq(g[4], -g[0]) and lt(g[5], 0))):
-            s = np.int(np.sign(g[4]))
+            s = int(np.sign(g[4]))
 
             A = I3.copy()
             A[0, 2] = -s
@@ -534,7 +534,7 @@ def niggli_reduce_cell(cell, epsfactor=None):
         elif (gt(abs(g[5]), g[0])
                 or (eq(g[5], g[0]) and lt(2 * g[3], g[4]))
                 or (eq(g[5], -g[0]) and lt(g[4], 0))):
-            s = np.int(np.sign(g[5]))
+            s = int(np.sign(g[5]))
 
             A = I3.copy()
             A[0, 1] = -s

--- a/ase/calculators/espresso/_ph.py
+++ b/ase/calculators/espresso/_ph.py
@@ -17,7 +17,7 @@ class EspressoPh(EspressoParent):
     ext_in = '.phi'
     ext_out = '.pho'
     implemented_properties = []
-    command = 'ph.x -in PREFIX.phi > PREFIX.pho'
+    command = 'ph.x -in PREFIX.phi > PREFIX.pho 2>&1'
 
     def __init__(self, *args, **kwargs):
         """

--- a/ase/geometry/dimensionality/topology_scaling.py
+++ b/ase/geometry/dimensionality/topology_scaling.py
@@ -82,7 +82,7 @@ class TSA:
         hist : tuple         Dimensionality histogram.
         """
         cdim = self._get_component_dimensionalities()
-        hist = np.zeros(4).astype(np.int)
+        hist = np.zeros(4).astype(int)
         bc = np.bincount(list(cdim.values()))
         hist[:len(bc)] = bc
         return tuple(hist)

--- a/ase/geometry/minkowski_reduction.py
+++ b/ase/geometry/minkowski_reduction.py
@@ -54,7 +54,7 @@ def closest_vector(t0, u, v):
 
 def reduction_full(B):
     """Calculate a Minkowski-reduced lattice basis (3D reduction)."""
-    H = np.eye(3).astype(np.int)
+    H = np.eye(3).astype(int)
     norms = np.linalg.norm(B, axis=1)
 
     max_it = 100000    # in practice this is not exceeded
@@ -122,7 +122,7 @@ def minkowski_reduce(cell, pbc=True):
     pbc = pbc2pbc(pbc)
     dim = pbc.sum()
 
-    op = np.eye(3).astype(np.int)
+    op = np.eye(3).astype(int)
     if dim == 2:
         perm = np.argsort(pbc, kind='merge')[::-1]    # stable sort
         pcell = cell[perm][:, perm]

--- a/ase/io/espresso/_koopmans_ham.py
+++ b/ase/io/espresso/_koopmans_ham.py
@@ -105,7 +105,7 @@ def read_koopmans_ham_out(fileobj):
                 line2 = flines[j_line].strip()
                 if len(line2) == 0:
                     break
-                eigenvalues[-1] += [float(x) for x in line2.split()]
+                eigenvalues[-1] += safe_string_to_list_of_floats(line2)
                 j_line += 1
 
         if 'INFO: KI[2nd] HAMILTONIAN CALCULATION ik=' in line:

--- a/ase/io/espresso/_utils.py
+++ b/ase/io/espresso/_utils.py
@@ -1086,9 +1086,15 @@ def safe_float(string):
 
 
 def safe_string_to_list_of_floats(string):
-    # Converts a string to a list of floats, but if string = 'number*******anothernumber' it returns
-    # [number, np.nan, anothernumber]. It also keeps its eye out for cases like numberanothernumber
+    '''
+    Converts a string to a list of floats, but if string = 'number*******anothernumber' it returns
+    [number, np.nan, anothernumber]. It also keeps its eye out for cases like numberanothernumber
+    and number-negativenumber
+    '''
+
     out = []
+
+    string.replace('-', ' -')
     for word in string.split():
         if '*' in word:
             # First, reduce each sequence of '*'s to a single '*'

--- a/ase/io/espresso/_wann2kc.py
+++ b/ase/io/espresso/_wann2kc.py
@@ -14,7 +14,7 @@ from ase.calculators.espresso import Wann2KC
 
 KEYS = Namelist((
     ('control', ['prefix', 'outdir', 'kcw_iverbosity', 'kcw_at_ks', 'calculation', 'lrpa',
-                 'mp1', 'mp2', 'mp3', 'homo_only', 'read_unitary_matrix', 'l_vcut', 'assume_isolated']),
+                 'mp1', 'mp2', 'mp3', 'homo_only', 'read_unitary_matrix', 'l_vcut', 'assume_isolated', 'spin_component']),
     ('wannier', ['seedname', 'check_ks', 'num_wann_occ', 'num_wann_emp', 'have_empty', 'has_disentangle'])))
 
 

--- a/ase/lattice/bravais.py
+++ b/ase/lattice/bravais.py
@@ -258,7 +258,7 @@ class Bravais:
         self.natoms = self.calc_num_atoms()
         self.nput = 0
         self.atoms = np.zeros((self.natoms, 3), np.float)
-        self.elements = np.zeros(self.natoms, np.int)
+        self.elements = np.zeros(self.natoms, int)
         self.farpoint = sum(self.directions)
         # printprogress = self.debug and (len(self.atoms) > 250)
         # Find the radius of the sphere containing the whole system

--- a/ase/neighborlist.py
+++ b/ase/neighborlist.py
@@ -768,7 +768,7 @@ class NewPrimitiveNeighborList:
             return True
 
         if ((self.pbc != pbc).any() or (self.cell != cell).any() or
-            ((self.positions - positions)**2).sum(1).max() > self.skin**2):
+                ((self.positions - positions)**2).sum(1).max() > self.skin**2):
             self.build(pbc, cell, positions, numbers=numbers)
             return True
 
@@ -869,7 +869,7 @@ class PrimitiveNeighborList:
             return True
 
         if ((self.pbc != pbc).any() or (self.cell != cell).any() or
-            ((self.coordinates - coordinates)**2).sum(1).max() > self.skin**2):
+                ((self.coordinates - coordinates)**2).sum(1).max() > self.skin**2):
             self.build(pbc, cell, coordinates)
             return True
 

--- a/ase/neighborlist.py
+++ b/ase/neighborlist.py
@@ -79,6 +79,7 @@ def get_distance_matrix(graph, limit=3):
     mat[mat == np.inf] = 0
     return sp.csr_matrix(mat, dtype=np.int8)
 
+
 def get_distance_indices(distanceMatrix, distance):
     """Get indices for each node that are distance or less away.
 
@@ -101,17 +102,16 @@ def get_distance_indices(distanceMatrix, distance):
     """
     shape = distanceMatrix.get_shape()
     indices = []
-    #iterate over rows
+    # iterate over rows
     for i in range(shape[0]):
         row = distanceMatrix.getrow(i)[0]
-        #find all non-zero
+        # find all non-zero
         found = sp.find(row)
-        #screen for smaller or equal distance
-        equal = np.where( found[-1] <= distance )[0]
-        #found[1] contains the indexes
-        indices.append([ found[1][x] for x in equal ])
+        # screen for smaller or equal distance
+        equal = np.where(found[-1] <= distance)[0]
+        # found[1] contains the indexes
+        indices.append([found[1][x] for x in equal])
     return indices
-
 
 
 def mic(dr, cell, pbc=True):
@@ -217,11 +217,11 @@ def primitive_neighbor_list(quantities, pbc, cell, positions, cutoff,
 
     # Return empty neighbor list if no atoms are passed here
     if len(positions) == 0:
-        empty_types = dict(i=(np.int, (0, )),
-                           j=(np.int, (0, )),
+        empty_types = dict(i=(int, (0, )),
+                           j=(int, (0, )),
                            D=(np.float, (0, 3)),
                            d=(np.float, (0, )),
-                           S=(np.int, (0, 3)))
+                           S=(int, (0, 3)))
         retvals = []
         for i in quantities:
             dtype, shape = empty_types[i]
@@ -249,7 +249,7 @@ def primitive_neighbor_list(quantities, pbc, cell, positions, cutoff,
             max_cutoff = cutoff
         else:
             cutoff = np.asarray(cutoff)
-            max_cutoff = 2*np.max(cutoff)
+            max_cutoff = 2 * np.max(cutoff)
 
     # We use a minimum bin size of 3 A
     bin_size = max(max_cutoff, 3)
@@ -273,7 +273,7 @@ def primitive_neighbor_list(quantities, pbc, cell, positions, cutoff,
     else:
         scaled_positions_ic = np.linalg.solve(complete_cell(cell).T,
                                               positions.T).T
-    bin_index_ic = np.floor(scaled_positions_ic*nbins_c).astype(int)
+    bin_index_ic = np.floor(scaled_positions_ic * nbins_c).astype(int)
     cell_shift_ic = np.zeros_like(bin_index_ic)
 
     for c in range(3):
@@ -282,7 +282,7 @@ def primitive_neighbor_list(quantities, pbc, cell, positions, cutoff,
             cell_shift_ic[:, c], bin_index_ic[:, c] = \
                 divmod(bin_index_ic[:, c], nbins_c[c])
         else:
-            bin_index_ic[:, c] = np.clip(bin_index_ic[:, c], 0, nbins_c[c]-1)
+            bin_index_ic[:, c] = np.clip(bin_index_ic[:, c], 0, nbins_c[c] - 1)
 
     # Convert Cartesian bin index to unique scalar bin index.
     bin_index_i = (bin_index_ic[:, 0] +
@@ -349,9 +349,9 @@ def primitive_neighbor_list(quantities, pbc, cell, positions, cutoff,
 
     # First atoms in pair.
     _first_at_neightuple_n = atoms_in_bin_ba[:, atom_pairs_pn[0]]
-    for dz in range(-neigh_search_z, neigh_search_z+1):
-        for dy in range(-neigh_search_y, neigh_search_y+1):
-            for dx in range(-neigh_search_x, neigh_search_x+1):
+    for dz in range(-neigh_search_z, neigh_search_z + 1):
+        for dy in range(-neigh_search_y, neigh_search_y + 1):
+            for dx in range(-neigh_search_x, neigh_search_x + 1):
                 # Bin index of neighboring bin and shift vector.
                 shiftx_xyz, neighbinx_xyz = divmod(binx_xyz + dx, nbins_c[0])
                 shifty_xyz, neighbiny_xyz = divmod(biny_xyz + dy, nbins_c[1])
@@ -427,7 +427,7 @@ def primitive_neighbor_list(quantities, pbc, cell, positions, cutoff,
         positions[first_at_neightuple_n] + \
         cell_shift_vector_n.dot(cell)
     abs_distance_vector_n = \
-        np.sqrt(np.sum(distance_vector_nc*distance_vector_nc, axis=1))
+        np.sqrt(np.sum(distance_vector_nc * distance_vector_nc, axis=1))
 
     # We have still created too many pairs. Only keep those with distance
     # smaller than max_cutoff.
@@ -638,10 +638,10 @@ def first_neighbors(natoms, first_atom):
         to s[k+1]-1.
     """
     if len(first_atom) == 0:
-        return np.zeros(natoms+1, dtype=int)
+        return np.zeros(natoms + 1, dtype=int)
     # Create a seed array (which is returned by this function) populated with
     # -1.
-    seed = -np.ones(natoms+1, dtype=int)
+    seed = -np.ones(natoms + 1, dtype=int)
 
     first_atom = np.asarray(first_atom)
 
@@ -655,16 +655,17 @@ def first_neighbors(natoms, first_atom):
     seed[-1] = len(first_atom)
     # Populate all intermediate seed with the index of where the mask array is
     # true, i.e. the index where the first_atom array changes.
-    seed[first_atom[1:][mask]] = (np.arange(len(mask))+1)[mask]
+    seed[first_atom[1:][mask]] = (np.arange(len(mask)) + 1)[mask]
 
     # Now fill all remaining -1 value with the value in the seed array right
     # behind them. (There are no neighbor so seed[i] and seed[i+1] must point)
     # to the same index.
     mask = seed == -1
     while mask.any():
-        seed[mask] = seed[np.arange(natoms+1)[mask]+1]
+        seed[mask] = seed[np.arange(natoms + 1)[mask] + 1]
         mask = seed == -1
     return seed
+
 
 def get_connectivity_matrix(nl, sparse=True):
     """Return connectivity matrix for a given NeighborList (dtype=numpy.int8).
@@ -759,7 +760,7 @@ class NewPrimitiveNeighborList:
         self.nneighbors = 0
         self.npbcneighbors = 0
 
-    def update(self,  pbc, cell, positions, numbers=None):
+    def update(self, pbc, cell, positions, numbers=None):
         """Make sure the list is up to date."""
 
         if self.nupdates == 0:
@@ -791,7 +792,7 @@ class NewPrimitiveNeighborList:
                 np.logical_and(
                     self.pair_first <= self.pair_second,
                     (self.offset_vec == 0).all(axis=1)
-                    ),
+                ),
                 np.logical_or(
                     self.offset_vec[:, 0] > 0,
                     np.logical_and(
@@ -801,10 +802,10 @@ class NewPrimitiveNeighborList:
                             np.logical_and(
                                 self.offset_vec[:, 1] == 0,
                                 self.offset_vec[:, 2] > 0)
-                            )
                         )
                     )
                 )
+            )
             self.pair_first = self.pair_first[mask]
             self.pair_second = self.pair_second[mask]
             self.offset_vec = self.offset_vec[mask]
@@ -836,8 +837,8 @@ class NewPrimitiveNeighborList:
         then get_neighbors(b) will not return a as a neighbor - unless
         bothways=True was used."""
 
-        return (self.pair_second[self.first_neigh[a]:self.first_neigh[a+1]],
-                self.offset_vec[self.first_neigh[a]:self.first_neigh[a+1]])
+        return (self.pair_second[self.first_neigh[a]:self.first_neigh[a + 1]],
+                self.offset_vec[self.first_neigh[a]:self.first_neigh[a + 1]])
 
 
 class PrimitiveNeighborList:
@@ -847,6 +848,7 @@ class PrimitiveNeighborList:
     scaled and non-scaled coordinates which may affect cell offsets
     through rounding errors.
     """
+
     def __init__(self, cutoffs, skin=0.3, sorted=False, self_interaction=True,
                  bothways=False, use_scaled_positions=False):
         self.cutoffs = np.asarray(cutoffs) + skin
@@ -922,7 +924,7 @@ class PrimitiveNeighborList:
 
         tree = cKDTree(positions, copy_data=True)
         offsets = cell.scaled_positions(positions - positions0)
-        offsets = offsets.round().astype(np.int)
+        offsets = offsets.round().astype(int)
 
         for n1, n2, n3 in itertools.product(range(0, N[0] + 1),
                                             range(-N[1], N[1] + 1),

--- a/ase/spectrum/band_structure.py
+++ b/ase/spectrum/band_structure.py
@@ -326,9 +326,10 @@ class BandStructure:
         depending on how the band structure was created."""
         return self._reference
 
-    def subtract_reference(self) -> 'BandStructure':
+    def subtract_reference(self, reference=None) -> 'BandStructure':
         """Return new band structure with reference energy subtracted."""
-        return BandStructure(self.path, self.energies - self.reference,
+        reference = reference if reference is not None else self.reference
+        return BandStructure(self.path, self.energies - reference,
                              reference=0.0)
 
     def todict(self):

--- a/ase/test/cell/test_minkowski_reduce.py
+++ b/ase/test/cell/test_minkowski_reduce.py
@@ -13,7 +13,6 @@ def run():
     tol = 1E-14
     rng = np.random.RandomState(0)
 
-
     cell = Cell([[8.972058879514716, 0.0009788104586639142, 0.0005932485724084841],
                  [4.485181755775297, 7.770520334862034, 0.00043663339838788054],
                  [4.484671994095723, 2.5902066679984634, 16.25695615743613]])
@@ -30,11 +29,10 @@ def run():
 
         # Test idempotency
         _, _H = minkowski_reduce(R)
-        assert (_H == np.eye(3).astype(np.int)).all()
+        assert (_H == np.eye(3).astype(int)).all()
 
         rcell, _ = Cell(B).minkowski_reduce()
         assert np.allclose(rcell, R, atol=tol)
-
 
     cell = np.array([[1, 1, 2], [0, 1, 4], [0, 0, 1]])
     unimodular = np.array([[1, 2, 2], [0, 1, 2], [0, 0, 1]])


### PR DESCRIPTION
Remove `np.int` because it is a deprecated alias for the builtin `int`

Added safer parsing of the eigenvalues in `.khi` files

Added an optional argument to `BandStructure.subtract_reference()` so that the band structures can be shifted by an arbitrary amount (convenient e.g. when plotting two band structures on top of one another)

Redirected the `stderr` of `ph.x` calculations to `stdout` 