### PR TITLE
Compliance with Wannier90 radial components

### DIFF
--- a/ase/io/wannier90.py
+++ b/ase/io/wannier90.py
@@ -473,6 +473,11 @@ def num_wann_lookup(proj):
         if l in database and '=' in mr:
             _, val = mr.split('=')
             return len(formatted_str_to_list(val))
+    elif proj.split(':')[0] in database:
+        l, r = proj.split(':')
+        if l in database and '=' in r:
+            _, val = r.split('=')
+            return len(formatted_str_to_list(val))
 
     raise NotImplementedError(f'Unrecognised Wannier90 projection {proj}')
 


### PR DESCRIPTION
ASE was not supporting the possibility of specifying the radial component of the atomic projection.

E.g. if we consider Mg, its pseudopotential normally includes 1s, 2s, and 2p orbitals in the valence shell. In Wannier90 one can distinguish between the 1s and the 2s orbitals (as well as for 2s and 3s, or for 3s and 4s, and so on), in the following way:
1s --> ``Mg: l=0``
2s --> ``Mg: l=0:r=2``

So far by specifying in the JSON file something like ``"ang_mtm": "l=0:r=2"``, the code would crash.
This PR fixes this little issue.