### PR TITLE
Resolution in band structure and DOS plots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ MANIFEST
 */.DS_Store
 *.traj
 /build
-/ase.egg-info
+/ase_koopmans.egg-info
 /ase/db/static/jsmol
 doc/ase/dft/bztable.rst
 doc/tutorials/deltacodesdft/fit.json

--- a/ase/dft/pdos.py
+++ b/ase/dft/pdos.py
@@ -273,13 +273,13 @@ class DOS:
 
 
 class DOSPlot:
-    def __init__(self, dos, ax=None,
+    def __init__(self, dos, ax=None, dpi=None,
                  emin=None, emax=None,
                  ymin=None, ymax=None, ylabel=None):
         self.dos = dos
         self.ax = ax
         if self.ax is None:
-            self.ax = self.prepare_plot(ax, emin, emax,
+            self.ax = self.prepare_plot(ax, dpi, emin, emax,
                                         ymin=ymin, ymax=ymax,
                                         ylabel=ylabel)
 
@@ -307,12 +307,13 @@ class DOSPlot:
 
         return ax
 
-    def prepare_plot(self, ax=None, emin=None, emax=None,
+    def prepare_plot(self, ax=None, dpi=None,
+                     emin=None, emax=None,
                      ymin=None, ymax=None,
                      ylabel=None, xlabel=None):
         import matplotlib.pyplot as plt
         if ax is None:
-            ax = plt.figure().add_subplot(111)
+            ax = plt.figure(dpi=dpi).add_subplot(111)
 
         ylabel = ylabel if ylabel is not None else 'DOS'
         xlabel = xlabel if xlabel is not None else 'Energy [eV]'

--- a/ase/spectrum/band_structure.py
+++ b/ase/spectrum/band_structure.py
@@ -155,7 +155,7 @@ class BandStructurePlot:
         self.show_legend = False
 
     def plot(self, ax=None, spin=None, emin=-10, emax=5, filename=None,
-             show=False, ylabel=None, colors=None, label=None,
+             dpi=None, show=False, ylabel=None, colors=None, label=None,
              spin_labels=['spin up', 'spin down'], loc=None, **plotkwargs):
         """Plot band-structure.
 
@@ -166,6 +166,8 @@ class BandStructurePlot:
             Maximum energy above reference.
         filename: str
             Write image to a file.
+        dpi: float
+            Image resolution
         ax: Axes
             MatPlotLib Axes object.  Will be created if not supplied.
         show: bool
@@ -173,7 +175,7 @@ class BandStructurePlot:
         """
 
         if self.ax is None:
-            ax = self.prepare_plot(ax, emin, emax, ylabel)
+            ax = self.prepare_plot(ax, dpi, emin, emax, ylabel)
 
         if spin is None:
             e_skn = self.bs.energies
@@ -210,7 +212,7 @@ class BandStructurePlot:
         return ax
 
     def plot_with_colors(self, ax=None, emin=-10, emax=5, filename=None,
-                         show=False, energies=None, colors=None,
+                         dpi=None, show=False, energies=None, colors=None,
                          ylabel=None, clabel='$s_z$', cmin=-1.0, cmax=1.0,
                          sortcolors=False, loc=None, s=2):
         """Plot band-structure with colors."""
@@ -218,7 +220,7 @@ class BandStructurePlot:
         import matplotlib.pyplot as plt
 
         if self.ax is None:
-            ax = self.prepare_plot(ax, emin, emax, ylabel)
+            ax = self.prepare_plot(ax, dpi, emin, emax, ylabel)
 
         shape = energies.shape
         xcoords = np.vstack([self.xcoords] * shape[1])
@@ -239,10 +241,10 @@ class BandStructurePlot:
 
         return ax
 
-    def prepare_plot(self, ax=None, emin=-10, emax=5, ylabel=None):
+    def prepare_plot(self, ax=None, dpi=None, emin=-10, emax=5, ylabel=None):
         import matplotlib.pyplot as plt
         if ax is None:
-            ax = plt.figure().add_subplot(111)
+            ax = plt.figure(dpi=dpi).add_subplot(111)
 
         def pretty(kpt):
             if kpt == 'G':


### PR DESCRIPTION
When calling the attribute `plot` of the class `BandStructurePlot`, or creating an instance of `DOSPlot`, it is possible to specify now the resolution of the plot via the variable `dpi`.