### PR TITLE
koffset as a list of floats

### DIFF
--- a/ase/calculators/espresso/_pw.py
+++ b/ase/calculators/espresso/_pw.py
@@ -33,7 +33,7 @@ class Espresso(EspressoParent):
         Generate a grid of k-points with this as the minimum distance,
         in A^-1 between them in reciprocal space. If set to None, kpts
         will be used instead.
-    kpts: (int, int, int), dict, list, or BandPath
+    kpts: (int, int, int), dict, or BandPath
         If kpts is a tuple (or list) of 3 integers, it is interpreted
         as the dimensions of a Monkhorst-Pack grid.
         If ``kpts`` is set to ``None``, only the Γ-point will be included
@@ -44,13 +44,12 @@ class Espresso(EspressoParent):
         If kpts is a dict, it will either be interpreted as a path
         in the Brillouin zone (*) if it contains the 'path' keyword,
         otherwise it is converted to a Monkhorst-Pack grid (**).
-        If kpts is a list, it will be interpreted as an explicit list
-        of points.
         (*) see ase.dft.kpoints.bandpath
         (**) see ase.calculators.calculator.kpts2sizeandoffsets
-    koffset: (int, int, int)
-        Offset of kpoints in each direction. Must be 0 (no offset) or
-        1 (half grid offset). Setting to True is equivalent to (1, 1, 1).
+    koffset: (int, int, int) or (float, float, float)
+        Offset of kpoints in each direction. Can be 0 (no offset) or
+        1 (half grid offset), or a float to get a generic grid offset.
+        Setting to True is equivalent to (1, 1, 1).
 
 
     .. note::

--- a/ase/calculators/espresso/_pw.py
+++ b/ase/calculators/espresso/_pw.py
@@ -15,7 +15,7 @@ from ._espresso import EspressoParent, error_template, warn_template
 
 class Espresso(EspressoParent):
     """
-    During initialisation, al options for pw.x are copied verbatim to
+    During initialisation, all options for pw.x are copied verbatim to
     the input file, and put into the correct section. Use ``input_data``
     for parameters that are already in a dict, all other ``kwargs`` are
     passed as parameters.
@@ -33,7 +33,7 @@ class Espresso(EspressoParent):
         Generate a grid of k-points with this as the minimum distance,
         in A^-1 between them in reciprocal space. If set to None, kpts
         will be used instead.
-    kpts: (int, int, int), dict, or BandPath
+    kpts: (int, int, int), dict, list, or BandPath
         If kpts is a tuple (or list) of 3 integers, it is interpreted
         as the dimensions of a Monkhorst-Pack grid.
         If ``kpts`` is set to ``None``, only the Γ-point will be included
@@ -44,6 +44,8 @@ class Espresso(EspressoParent):
         If kpts is a dict, it will either be interpreted as a path
         in the Brillouin zone (*) if it contains the 'path' keyword,
         otherwise it is converted to a Monkhorst-Pack grid (**).
+        If kpts is a list, it will be interpreted as an explicit list
+        of points.
         (*) see ase.dft.kpoints.bandpath
         (**) see ase.calculators.calculator.kpts2sizeandoffsets
     koffset: (int, int, int)

--- a/ase/io/espresso/_koopmans_cp.py
+++ b/ase/io/espresso/_koopmans_cp.py
@@ -191,7 +191,7 @@ def read_koopmans_cp_out(fileobj, index=-1, results_required=True):
             convergence[convergence_key].append(entry)
 
         if 'wall time' in line:
-            time_str = line.split(',')[1].strip().rstrip('wall time')
+            time_str = line.split(',')[1].strip().rstrip('time').rstrip('wall ')
             walltime = time_to_float(time_str)
 
     # Put everything together

--- a/ase/io/espresso/_utils.py
+++ b/ase/io/espresso/_utils.py
@@ -6,7 +6,7 @@ Written by Edward Linscott 2020-21
 
 import warnings
 import os
-from ase.dft.kpoints import BandPath, labels_from_kpts, get_monkhorst_pack_size_and_offset
+from ase.dft.kpoints import BandPath, labels_from_kpts, get_monkhorst_pack_size_and_offset, monkhorst_pack
 import numpy as np
 from pathlib import Path
 import operator as op
@@ -1018,7 +1018,7 @@ def construct_kpoints_card(atoms, kpts=None, kspacing=None, koffset=(0, 0, 0)):
         kgrid = "gamma"
 
     # True and False work here and will get converted by ':d' format
-    if isinstance(koffset, int):
+    if isinstance(koffset, (int, float)):
         koffset = (koffset, ) * 3
 
     # BandPath object or bandpath-as-dictionary:
@@ -1033,11 +1033,12 @@ def construct_kpoints_card(atoms, kpts=None, kspacing=None, koffset=(0, 0, 0)):
     elif isinstance(kgrid, str) and (kgrid == "gamma"):
         out.append('K_POINTS gamma\n')
         out.append('\n')
-    elif isinstance(kgrid, list):
+    elif any([isinstance(i, float) for i in koffset]):
+        klist = monkhorst_pack(kgrid) + koffset
         out.append('K_POINTS crystal\n')
-        assert len(kgrid) > 0
-        out.append('%s\n' % len(kgrid))
-        for k in kgrid:
+        assert len(klist) > 0
+        out.append('%s\n' % len(klist))
+        for k in klist:
             out.append('{k[0]:.14f} {k[1]:.14f} {k[2]:.14f} 1.0\n'.format(k=k))
         out.append('\n')
     else:

--- a/ase/io/wannier90.py
+++ b/ase/io/wannier90.py
@@ -1,7 +1,7 @@
 """
 This module defines I/O routines with wannier90 files.
 For the moment, no attempt has been made to put construct ASE atoms objects correctly.
-Instead, everything is stored in ase.calc.parmaeters
+Instead, everything is stored in ase.calc.parameters
 """
 
 import re


### PR DESCRIPTION
With this PR we allow `koffset` to be a list of floats (or a single float) rather than a list of integers.
When `koffset` is a list of integers it behaves as before, while for a list of floats ASE will create a `K_POINTS` card where the k-points are listed explicitly after applying the offset to the grid.