### PR TITLE
Adding support for `h_diag_scheme` in kcw ham

### DIFF
--- a/ase_koopmans/io/espresso/_koopmans_ham.py
+++ b/ase_koopmans/io/espresso/_koopmans_ham.py
@@ -16,7 +16,7 @@ from ._wann2kc import KEYS as W2KCW_KEYS
 from ase_koopmans.calculators.espresso import KoopmansHam
 
 KEYS = copy.deepcopy(W2KCW_KEYS)
-KEYS['HAM'] = ['do_bands', 'use_ws_distance', 'write_hr', 'l_alpha_corr', 'on_site_only']
+KEYS['HAM'] = ['do_bands', 'use_ws_distance', 'write_hr', 'l_alpha_corr', 'on_site_only', 'h_diag_scheme']
 
 
 def write_koopmans_ham_in(fd, atoms, input_data=None, pseudopotentials=None,

--- a/ase_koopmans/io/espresso/_koopmans_ham.py
+++ b/ase_koopmans/io/espresso/_koopmans_ham.py
@@ -104,6 +104,9 @@ def read_koopmans_ham_out(fileobj):
         if 'INFO: KI[2nd] HAMILTONIAN CALCULATION ik=' in line:
             ks_eigenvalues_on_grid.append([])
             ki_eigenvalues_on_grid.append([])
+        elif 'INFO: qKI  HAMILTONIAN CALCULATION ik=' in line: # new format.
+            ks_eigenvalues_on_grid.append([])
+            ki_eigenvalues_on_grid.append([])
 
         if line.startswith('          KS '):
             ks_eigenvalues_on_grid[-1] += safe_string_to_list_of_floats(line.replace('KS', ''))

--- a/ase_koopmans/io/espresso/_koopmans_ham.py
+++ b/ase_koopmans/io/espresso/_koopmans_ham.py
@@ -87,6 +87,7 @@ def read_koopmans_ham_out(fileobj):
     eigenvalues = []
     ks_eigenvalues_on_grid = []
     ki_eigenvalues_on_grid = []
+    pki_eigenvalues_on_grid = [] # pKI, perturbative KI.
 
     for i_line, line in enumerate(flines):
 
@@ -107,6 +108,7 @@ def read_koopmans_ham_out(fileobj):
         elif 'INFO: qKI  HAMILTONIAN CALCULATION ik=' in line: # new format.
             ks_eigenvalues_on_grid.append([])
             ki_eigenvalues_on_grid.append([])
+            pki_eigenvalues_on_grid.append([])
 
         if line.startswith('          KS '):
             ks_eigenvalues_on_grid[-1] += safe_string_to_list_of_floats(line.replace('KS', ''))
@@ -114,6 +116,9 @@ def read_koopmans_ham_out(fileobj):
         if line.startswith('          KI '):
             ki_eigenvalues_on_grid[-1] += safe_string_to_list_of_floats(line.replace('KI', ''))
 
+        if line.startswith('          pKI '):
+            pki_eigenvalues_on_grid[-1] += safe_string_to_list_of_floats(line.replace('pKI', ''))
+        
         if 'JOB DONE' in line:
             job_done = True
 
@@ -132,6 +137,7 @@ def read_koopmans_ham_out(fileobj):
     calc.results['eigenvalues'] = eigenvalues
     calc.results['ks_eigenvalues_on_grid'] = ks_eigenvalues_on_grid
     calc.results['ki_eigenvalues_on_grid'] = ki_eigenvalues_on_grid
+    calc.results['pki_eigenvalues_on_grid'] = pki_eigenvalues_on_grid
     structure.calc = calc
 
     yield structure

--- a/ase_koopmans/io/espresso/_pw.py
+++ b/ase_koopmans/io/espresso/_pw.py
@@ -379,7 +379,7 @@ def read_pw_out(fileobj, index=-1, results_required=True):
         nelec = None
         for nelec_index in indexes[_PW_NELEC]:
             if image_index < nelec_index < next_index:
-                nelec = float(pwo_lines[nelec_index].split()[-1])
+                nelec = float(pwo_lines[nelec_index].split()[-1].replace(')',""))
 
         # Put everything together
         calc = SinglePointDFTCalculator(structure, energy=energy,

--- a/ase_koopmans/io/espresso/_utils.py
+++ b/ase_koopmans/io/espresso/_utils.py
@@ -1109,7 +1109,7 @@ def safe_string_to_list_of_floats(string):
 
     out = []
 
-    string.replace('-', ' -')
+    string = string.replace('-', ' -')
     for word in string.split():
         if '*' in word:
             # First, reduce each sequence of '*'s to a single '*'


### PR DESCRIPTION
in passing by, I fixed a `string.replace` in [ase_koopmans/io/espresso/_utils.py](https://github.com/elinscott/ase_koopmans/compare/rename_package...mikibonacci:ase_koopmans:ki_proj?expand=1#diff-e25d5d8ec4035b2271af6ae3c3e280f35ad3c9e48cb410a3bb5c6b976cce92d5), as it was not assigned again to `string`, so the cases like "-1222.2344-122.3455" were not really fixed by the replace (giving nan and so problems in storing eigenvalues in AiiDA db)